### PR TITLE
Support for ORIG_PATH_INFO

### DIFF
--- a/toro.php
+++ b/toro.php
@@ -53,7 +53,7 @@ class ToroApplication {
         if (isset($_SERVER['ORIG_PATH_INFO'])) {
             $path_info = $_SERVER['ORIG_PATH_INFO'];
         }
-    
+        
         $request_method = strtolower($_SERVER['REQUEST_METHOD']);
         $discovered_handler = NULL;
         $regex_matches = array();


### PR DESCRIPTION
Hello again, Kunal. Hope you're well.

I noticed an issue reported in ToroPHP for servers that don't support `$_SERVER['PATH_INFO']`. I know my production environment places the same information in a key called `ORIG_PATH_INFO`—the reason is something to do with PHP being compiled via CGI. Therefore, I've added a check for this key when populating the `$path_info` variable for routing.

Regards,
Martin
