### PR TITLE
Replaced $_SERVER['PATH_INFO'] variable

### DIFF
--- a/toro.php
+++ b/toro.php
@@ -5,7 +5,12 @@ class Toro {
         ToroHook::fire('before_request');
 
         $request_method = strtolower($_SERVER['REQUEST_METHOD']);
-        $path_info = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : '/';
+        
+        //rebuild URL, then parse for path
+        $scheme = (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS'] != 'off')) ? 'https://' : 'http://';
+        $url = $scheme.$_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];
+        $path_info = parse_url($url, PHP_URL_PATH);
+
         $discovered_handler = NULL;
         $regex_matches = array();
 


### PR DESCRIPTION
`$_SERVER['PATH_INFO']` isn't set by default on many servers. For instance, the existing code would not work on NGINX by default.

There is no 100% perfect way to do it, really, but this way is easy and clean.

Replaced the direct call to the `$_SERVER` var with code that rebuilds the request URL then parses it for the path.

Tested on Apache and Nginx
