### PR TITLE
Optional parameter for passing in $path_info to Toro

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -17,13 +17,13 @@ class Toro
         }
         else if ($routes) {
             $tokens = array(
-                ':string' => '([a-zA-Z]+)',
-                ':number' => '([0-9]+)',
-                ':alpha'  => '([a-zA-Z0-9-_]+)'
+                ':alpha' => '([\p{L}_]+)',
+                ':number' => '([\p{Nd}]+)',
+                ':alphanum'  => '([\p{L}\p{Nd}\p{Pd}_]+)'
             );
             foreach ($routes as $pattern => $handler_name) {
                 $pattern = strtr($pattern, $tokens);
-                if (preg_match('#^/?' . $pattern . '/?$#', $path_info, $matches)) {
+                if (preg_match('#^/?' . $pattern . '/?$#u', $path_info, $matches)) {
                     $discovered_handler = $handler_name;
                     $regex_matches = $matches;
                     break;


### PR DESCRIPTION
The regular .htaccess for ToroPHP didn't work at my webhost so had to pass the path_info as a get parameter instead, like this:

```
RewriteRule .* index.php?toro_uri=/$0 [PT,L,QSA]
```

Toro of course doesn't know about that, so I figured it would be nice if you could optionally pass in your own path_info like this:

```
Toro::serve(array(
    "/" => "Controller_Home",
), isset($_GET['toro_uri']) ? $_GET['toro_uri'] : NULL);
```

And with this change you can :)
