### PR TITLE
Add PHP long tags

### DIFF
--- a/examples/blog/handlers/article_handler.php
+++ b/examples/blog/handlers/article_handler.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 class ArticleHandler {
     function get($slug) {
         $article = get_article_by_slug($slug);

--- a/examples/blog/handlers/articles_handler.php
+++ b/examples/blog/handlers/articles_handler.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 class ArticlesHandler {
     function get() {
         $articles = get_articles();

--- a/examples/blog/handlers/comment_handler.php
+++ b/examples/blog/handlers/comment_handler.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 class CommentHandler {
     function post($slug) {
         $article = get_article_by_slug($slug);

--- a/examples/blog/index.php
+++ b/examples/blog/index.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 require("handlers/article_handler.php");
 require("handlers/articles_handler.php");
 require("handlers/comment_handler.php");

--- a/examples/blog/lib/mysql.php
+++ b/examples/blog/lib/mysql.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 class MySQL {
   private static $instance = NULL;
 

--- a/examples/blog/lib/queries.php
+++ b/examples/blog/lib/queries.php
@@ -1,4 +1,5 @@
-<?
+<?php
+
 function get_articles() {
     $query = MySQL::getInstance()->query("SELECT * FROM articles ORDER BY published DESC");
     return $query->fetchAll();

--- a/examples/hello_world/hello.php
+++ b/examples/hello_world/hello.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 require("toro.php");
 

--- a/examples/queue/handlers/dashboard_handler.php
+++ b/examples/queue/handlers/dashboard_handler.php
@@ -1,4 +1,5 @@
 <?php
+
 class DashboardHandler {
     function get() {
         $stats = get_stats();

--- a/examples/queue/handlers/receive_handler.php
+++ b/examples/queue/handlers/receive_handler.php
@@ -1,4 +1,5 @@
 <?php
+
 class ReceiveHandler {
     function get_xhr() {
         echo json_encode(array("payload" => receive_payload()));

--- a/examples/queue/handlers/send_handler.php
+++ b/examples/queue/handlers/send_handler.php
@@ -1,4 +1,5 @@
 <?php
+
 class SendHandler {
     function post() {
         if (isset($_POST['payload']) && strlen(trim($_POST['payload'])) > 0) {

--- a/examples/queue/handlers/stats_handler.php
+++ b/examples/queue/handlers/stats_handler.php
@@ -1,4 +1,5 @@
 <?php
+
 class StatsHandler {
     function get_xhr() {
         echo json_encode(get_stats());

--- a/examples/queue/index.php
+++ b/examples/queue/index.php
@@ -1,4 +1,5 @@
 <?php
+
 require("handlers/dashboard_handler.php");
 require("handlers/receive_handler.php");
 require("handlers/send_handler.php");

--- a/examples/queue/lib/mysql.php
+++ b/examples/queue/lib/mysql.php
@@ -1,4 +1,5 @@
 <?php
+
 class MySQL {
   private static $instance = NULL;
 

--- a/examples/queue/lib/queries.php
+++ b/examples/queue/lib/queries.php
@@ -1,4 +1,5 @@
 <?php
+
 function get_queue_size() {
     $query = MySQL::getInstance()->query("SELECT count(id) as count FROM queue");
     $result = $query->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
The example code was using PHP short tags in some files, which require a non-default ini setting and are deprecated
