### PR TITLE
Support for IIS

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -8,8 +8,7 @@ class Toro
 
         $request_method = strtolower($_SERVER['REQUEST_METHOD']);
         $path_info = '/';
-        $path_info = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : (isset($_SERVER['ORIG_PATH_INFO']) ? $_SERVER['ORIG_PATH_INFO'] : $path_info);
-        $discovered_handler = null;
+        $path_info = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : ((isset($_SERVER['ORIG_PATH_INFO']) and $_SERVER['ORIG_PATH_INFO'] !== "/index.php") ? $_SERVER['ORIG_PATH_INFO'] : $path_info);        $discovered_handler = null;
         $regex_matches = array();
 
         if (isset($routes[$path_info])) {


### PR DESCRIPTION
The $_SERVER['ORIG_PATH_INFO'] on IIS return '/index.php' on the root of the website, and Toro expect just '/'. So I added a conditional test to avoid that problem.

Maybe not the prettiest solution, but works fine on IIS and Apache.
