### PR TITLE
Added ability to set route prefixes

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -2,7 +2,7 @@
 
 class Toro
 {
-    public static function serve($routes, $route_prefix = '', $route_case_sensitive = true)
+    public static function serve($routes, $route_prefix = '')
     {
         ToroHook::fire('before_request');
 		
@@ -28,7 +28,6 @@ class Toro
         else {
             if (!empty($_SERVER['REQUEST_URI'])) {
                 $path_info = (strpos($_SERVER['REQUEST_URI'], '?') > 0) ? strstr($_SERVER['REQUEST_URI'], '?', true) : $_SERVER['REQUEST_URI'];
-                $path_info = $route_case_sensitive ? $path_info : strtolower($path_info); //Make path lowercase if configured that way
             }
         }
         


### PR DESCRIPTION
Added ability to set route prefixes so that Toro can easily be used to serve content from a subfolder.

Now we can pass the folder prefix as the second parameter to Toro::serve() and all paths will be correctly matched inside the subfolder.

Example (Serving application from /mysite)

``` php
Toro::serve(
    array(
        "/" => "HelloWorld",
        "/about" => "About",
    ), '/mysite');
```

All routes will now have /mysite prepended to them, so in our example the routes would be:
/mysite/
/mysite/about
