### PR TITLE
Passing parsed information from Toro::server into ToroHook::fire() methods

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -4,7 +4,7 @@ class Toro
 {
     public static function serve($routes)
     {
-        ToroHook::fire('before_request');
+        ToroHook::fire('before_request', compact('routes'));
 
         $request_method = strtolower($_SERVER['REQUEST_METHOD']);
         $path_info = '/';
@@ -42,6 +42,7 @@ class Toro
             }
         }
 
+        $result = null;
         if ($discovered_handler && class_exists($discovered_handler)) {
             unset($regex_matches[0]);
             $handler_instance = new $discovered_handler();
@@ -57,19 +58,19 @@ class Toro
             }
 
             if (method_exists($handler_instance, $request_method)) {
-                ToroHook::fire('before_handler');
-                call_user_func_array(array($handler_instance, $request_method), $regex_matches);
-                ToroHook::fire('after_handler');
+                ToroHook::fire('before_handler', compact('routes', 'discovered_handler', 'request_method'));
+                $result = call_user_func_array(array($handler_instance, $request_method), $regex_matches);
+                ToroHook::fire('after_handler', compact('routes', 'discovered_handler', 'request_method', 'result'));
             }
             else {
-                ToroHook::fire('404');
+                ToroHook::fire('404', compact('routes', 'discovered_handler', 'request_method'));
             }
         }
         else {
-            ToroHook::fire('404');
+            ToroHook::fire('404', compact('routes', 'discovered_handler', 'request_method'));
         }
 
-        ToroHook::fire('after_request');
+        ToroHook::fire('after_request', compact('routes', 'discovered_handler', 'request_method', 'result'));
     }
 
     private static function is_xhr_request()


### PR DESCRIPTION
This will allow handlers access to some valuable information from the Toro::server method.  Information such as routes, discovered_handler, request_method and the result of the handler method call (if any) to be used on other fired methods.  This can be used to setup and ACL or templates.
