### PR TITLE
Adding the $regex_match variable to parameters sent to ToroHook

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -58,19 +58,19 @@ class Toro
             }
 
             if (method_exists($handler_instance, $request_method)) {
-                ToroHook::fire('before_handler', compact('routes', 'discovered_handler', 'request_method'));
+                ToroHook::fire('before_handler', compact('routes', 'discovered_handler', 'request_method', 'regex_matches'));
                 $result = call_user_func_array(array($handler_instance, $request_method), $regex_matches);
-                ToroHook::fire('after_handler', compact('routes', 'discovered_handler', 'request_method', 'result'));
+                ToroHook::fire('after_handler', compact('routes', 'discovered_handler', 'request_method', 'regex_matches', 'result'));
             }
             else {
-                ToroHook::fire('404', compact('routes', 'discovered_handler', 'request_method'));
+                ToroHook::fire('404', compact('routes', 'discovered_handler', 'request_method', 'regex_matches'));
             }
         }
         else {
-            ToroHook::fire('404', compact('routes', 'discovered_handler', 'request_method'));
+            ToroHook::fire('404', compact('routes', 'discovered_handler', 'request_method', 'regex_matches'));
         }
 
-        ToroHook::fire('after_request', compact('routes', 'discovered_handler', 'request_method', 'result'));
+        ToroHook::fire('after_request', compact('routes', 'discovered_handler', 'request_method', 'regex_matches', 'result'));
     }
 
     private static function is_xhr_request()


### PR DESCRIPTION
This is an addition to my previous request.  I seemed to have missed the "regex_match" variable.  I've now included it in the parameters passed into each ToroHook::fire closure.
