### PR TITLE
Added Toro::hashandlerfor function to check if a route is served or not

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -8,9 +8,11 @@ class Toro
 
     public static function hasHandlerFor($path_info)
     {
-        if (isset(self::$used_routes[$path_info]))
+        if (isset(self::$used_routes[$path_info])) {
             return true;
-            foreach (self::$used_routes as $pattern => $handler_name) {
+        }
+        
+        foreach (self::$used_routes as $pattern => $handler_name) {
             $pattern = strtr($pattern, self::$used_tokens);
             if (preg_match('#^/?' . $pattern . '/?$#', $path_info, $matches)) {
                 return true;


### PR DESCRIPTION
We needed a good way of checking if a route is served or not. So that we can serve different routes depending on user access.  

Sample code:

function GenHREF($href, $caption)
{
        /*
         \* custom href that knows about toro-handlers
         \* 
         \* result if foo refers to a toro-handler :
         \*        <a href=foo>bar</a>
         \* result if foo doesn't refer to a toro-handler :
         \*        bar
         */
        if (Toro::hashandlerfor($href))
                return "<a href='$href'>$caption</a>";
        else
                return $caption;
}
