### PR TITLE
forgot to add the extratokens variable to the serve function

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -21,7 +21,7 @@ class Toro
         return false;
     }
 
-    public static function serve($routes)
+    public static function serve($routes, $extratokens = null)
     {
         self::$used_routes = $routes;
         self::$used_tokens = array(


### PR DESCRIPTION
Added $extratokens to the server() fuction.

Sample usage:
    Toro::serve(array(
                "/"                              => "MainPageHandler",
                "/users"                      => "UsersHandlerShow",
                "/users/:userid/edit"     => "UsersHandlerEdit",
                ), array(':userid' => CurrentUserID())); // CurrentUserID() in this case returns the userid of the currently logged in user.
