### PR TITLE
Better method of checking if request is XHR

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -85,7 +85,7 @@ class Toro
 
     private static function is_xhr_request()
     {
-        return strpos($_SERVER['HTTP_ACCEPT'], "application/json") == 0;
+        return strpos($_SERVER['HTTP_ACCEPT'], "application/json") === 0;
     }
 }
 

--- a/src/Toro.php
+++ b/src/Toro.php
@@ -85,7 +85,7 @@ class Toro
 
     private static function is_xhr_request()
     {
-        return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest';
+        return strpos($_SERVER['HTTP_ACCEPT'], "application/json") == 0;
     }
 }
 


### PR DESCRIPTION
While most AJAX frameworks have support for the X-Requested-With header, others are dropping it, citing low usage.

Angular:
https://github.com/angular/angular.js/commit/3a75b1124d062f64093a90b26630938558909e8d

I also believe this is a better way of determining what content to send back for building APIs, despite that it is not actually checking whether the request was XHR.
