### PR TITLE
Add FallbackResource in documentation [Follow up]

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,13 @@ $ php composer.phar install
 ### Server Configuration
 
 You may need to add the following snippet in your Apache HTTP Server virtual
-host configuration or `.htaccess`:
+host configuration or `.htaccess`.
 
+Apache >= 2.2.16:
+```apacheconf
+FallbackResource /index.php
+```
+Apache < 2.2.16: 
 ```apacheconf
 RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
So this is the follow up to my [last request](https://github.com/anandkunal/ToroPHP/pull/72). It just **adds** the encouraged use of `FallbackResource` to the documentation.

http://httpd.apache.org/docs/trunk/rewrite/remapping.html#fallback-resource

>    As of version 2.2.16, you should use the FallbackResource directive for this
