### PR TITLE
Simplify PATH_INFO fallback

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -16,7 +16,10 @@ class Toro
         }
         else {
             if (!empty($_SERVER['REQUEST_URI'])) {
-                $path_info = (strpos($_SERVER['REQUEST_URI'], '?') > 0) ? strstr($_SERVER['REQUEST_URI'], '?', true) : $_SERVER['REQUEST_URI'];
+                $path_info = strtok($_SERVER['REQUEST_URI'], '?');
+            }
+            else{
+                die("Unable to route.");
             }
         }
         


### PR DESCRIPTION
The current path_info fallback is a bit tough to read, a `strtok` call is simpler: it always returns the query-string-less URI.
