### PR TITLE
Adding support for custom methods on handlers

### DIFF
--- a/src/Toro.php
+++ b/src/Toro.php
@@ -46,6 +46,13 @@ class Toro
 
         $handler_instance = null;
         if ($discovered_handler) {
+
+        	if (strpos($discovered_handler, '@') !== false) {
+        		$arr = explode('@', $discovered_handler);
+        		$discovered_handler = $arr[0];
+        		$request_method = $arr[1];
+        	}
+
             if (is_string($discovered_handler)) {
                 $handler_instance = new $discovered_handler();
             }


### PR DESCRIPTION
I was thinking of adding the ability to be able to call specific methods when defining handlers in routes. Much like the router in Laravel. So instead of:

"/route/name" => "Handler"

We could have:

"/route/name" => "Handler@methodName"

Which would call the specific method on that handler.